### PR TITLE
🚀 Add comparison confidence metadata

### DIFF
--- a/src/arbitron/competition.py
+++ b/src/arbitron/competition.py
@@ -131,6 +131,7 @@ class Competition(BaseModel):
             "item_a",
             "item_b",
             "winner",
+            "comparison_confidence",
             "comparison_created_at",
             "comparison_cost",
         ]
@@ -145,6 +146,7 @@ class Competition(BaseModel):
                     "item_a": comparison.item_a,
                     "item_b": comparison.item_b,
                     "winner": comparison.winner,
+                    "comparison_confidence": f"{comparison.confidence:.4f}",
                     "comparison_created_at": comparison.created_at.isoformat(),
                     "comparison_cost": (
                         str(comparison.cost) if comparison.cost is not None else ""

--- a/src/arbitron/juror.py
+++ b/src/arbitron/juror.py
@@ -7,7 +7,7 @@ from typing import Any
 from pydantic_ai import Agent as PydanticAgent
 from pydantic_ai.messages import ModelResponse
 
-from .models import Comparison, ComparisonChoice, Item, Juror
+from .models import Comparison, ComparisonChoice, ComparisonVerdict, Item, Juror
 
 
 def _default_instructions(juror: Juror) -> str:
@@ -22,7 +22,9 @@ You are an expert juror.
 
 ## Output
 
-Return `choice` as either "item_a" or "item_b".""".strip()
+Return your output as JSON with two keys:
+- `choice`: either "item_a" or "item_b"
+- `confidence`: a number between 0 and 1""".strip()
 
 
 def _value_to_xml(tag: str, value: Any) -> str:
@@ -70,7 +72,7 @@ def _build_user_prompt(description: str, item_a: Item, item_b: Item) -> str:
 
 <instruction>
 Compare the two items above and determine which one better fulfills the task requirements.
-Return your choice as either "item_a" or "item_b".
+Return your choice as either "item_a" or "item_b" and provide a confidence score between 0 and 1.
 </instruction>"""
 
 
@@ -78,10 +80,10 @@ def _resolve_agent(juror: Juror, instructions: str) -> PydanticAgent:
     """Return a Juror-ready Agent, using defaults when needed."""
     agent = juror.agent
     if agent is None:
-        agent = PydanticAgent[None, ComparisonChoice](
+        agent = PydanticAgent[None, ComparisonVerdict](
             model=juror.model or "openai:gpt-5-nano",
             instructions=instructions,
-            output_type=ComparisonChoice,
+            output_type=ComparisonVerdict,
             retries=3,
         )
     if isinstance(agent, PydanticAgent):
@@ -125,10 +127,11 @@ async def run_juror(
     agent = _resolve_agent(juror, instructions)
 
     result = await agent.run(user_prompt)
-    try:
-        choice: ComparisonChoice = ComparisonChoice(result.output)
-    except ValueError as exc:  # pragma: no cover - defensive
-        raise TypeError("Juror output must be 'item_a' or 'item_b'") from exc
+    verdict = result.output
+    if not isinstance(verdict, ComparisonVerdict):  # pragma: no cover - defensive
+        raise TypeError("Juror output must include choice and confidence")
+
+    choice = verdict.choice
 
     winner = item_a.id if choice is ComparisonChoice.item_a else item_b.id
 
@@ -140,6 +143,7 @@ async def run_juror(
         item_a=item_a.id,
         item_b=item_b.id,
         winner=winner,
+        confidence=verdict.confidence,
         created_at=datetime.now(timezone.utc),
         cost=comparison_cost,
     )

--- a/src/arbitron/models.py
+++ b/src/arbitron/models.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel as PydanticBaseModel, ConfigDict, model_validator
+from pydantic import BaseModel as PydanticBaseModel, ConfigDict, Field, model_validator
 
 
 class Item(PydanticBaseModel):
@@ -69,10 +69,16 @@ class ComparisonChoice(str, Enum):
     item_b = "item_b"
 
 
+class ComparisonVerdict(PydanticBaseModel):
+    choice: ComparisonChoice
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
 class Comparison(PydanticBaseModel):
     juror_id: str
     item_a: str
     item_b: str
     winner: str
+    confidence: float = Field(ge=0.0, le=1.0)
     created_at: datetime
     cost: Decimal | None = None

--- a/tests/test_competition.py
+++ b/tests/test_competition.py
@@ -11,7 +11,7 @@ from pydantic_ai.models.test import TestModel
 
 from arbitron import Competition, Item, Juror
 from arbitron.juror import _build_user_prompt, _format_item_block, _resolve_agent
-from arbitron.models import Comparison, ComparisonChoice
+from arbitron.models import Comparison, ComparisonChoice, ComparisonVerdict
 from arbitron.pairing import AllPairsSampler, PairSampler, RandomPairsSampler
 from arbitron.runner import _randomize_pair_orientations
 
@@ -26,7 +26,7 @@ def _build_test_juror(juror_id: str = "unit-test") -> Juror:
     agent = Agent(
         model=TestModel(),
         instructions="Fake juror used for unit tests.",
-        output_type=ComparisonChoice,
+        output_type=ComparisonVerdict,
     )
     return Juror(id=juror_id, agent=agent)
 
@@ -337,6 +337,7 @@ def test_competition_seed_reproducible(monkeypatch: pytest.MonkeyPatch):
             item_a=item_a.id,
             item_b=item_b.id,
             winner=item_a.id,
+            confidence=0.75,
             created_at=datetime.now(timezone.utc),
             cost=None,
         )
@@ -421,7 +422,7 @@ def test_juror_rejects_agent_and_model():
     agent = Agent(
         model=TestModel(),
         instructions="Fake juror used for unit tests.",
-        output_type=ComparisonChoice,
+        output_type=ComparisonVerdict,
     )
 
     with pytest.raises(ValueError, match="either `agent` or `model`"):


### PR DESCRIPTION
Adds structured confidence to comparison results, updates juror agents to request it, and surfaces the new values in exports and tests.